### PR TITLE
Update customisation.md to reflect current code

### DIFF
--- a/docs/Fable.Form.Simple/customisation.md
+++ b/docs/Fable.Form.Simple/customisation.md
@@ -20,31 +20,24 @@ module Form =
 
     module View =
 
-        // Uncomment, the line corresponding to your preferred DOM library
+        // Uncomment the line corresponding to your preferred DOM library
         // open Feliz
         // open Fable.React
 
-        // Open the differents modules we need to have access to
+        // Open the different modules we need to have access to
         open Fable.Form
         open Fable.Form.Simple
         open Fable.Form.Simple.Form.View
 
         // Contract that we need to implement to support
         // all the feature offered by Fable.Simple.Form
-        let htmlViewConfig<'Msg> : CustomConfig<'Msg> =
+        let htmlViewConfig<'Msg> : CustomConfig<'Msg, IReactProperty> =
             {
                 Form = failwith "Not implemented yet"
                 TextField = failwith "Not implemented yet"
                 PasswordField = failwith "Not implemented yet"
                 EmailField = failwith "Not implemented yet"
                 TextAreaField = failwith "Not implemented yet"
-                CheckboxField = failwith "Not implemented yet"
-                RadioField = failwith "Not implemented yet"
-                SelectField = failwith "Not implemented yet"
-                Group = failwith "Not implemented yet"
-                Section = failwith "Not implemented yet"
-                FormList = failwith "Not implemented yet"
-                FormListItem = failwith "Not implemented yet"
                 ColorField = failwith "Not implemented yet"
                 DateField = failwith "Not implemented yet"
                 DateTimeLocalField = failwith "Not implemented yet"
@@ -52,6 +45,13 @@ module Form =
                 SearchField = failwith "Not implemented yet"
                 TelField = failwith "Not implemented yet"
                 TimeField = failwith "Not implemented yet"
+                CheckboxField = failwith "Not implemented yet"
+                RadioField = failwith "Not implemented yet"
+                SelectField = failwith "Not implemented yet"
+                Group = failwith "Not implemented yet"
+                Section = failwith "Not implemented yet"
+                FormList = failwith "Not implemented yet"
+                FormListItem = failwith "Not implemented yet"
             }
 
         // Function which will be called by the consumer to render the form
@@ -59,4 +59,4 @@ module Form =
             custom htmlViewConfig config
 ```
 
-You can take a look at [Fable.Form.Simple.Bulma](https://github.com/MangelMaxime/Fable.Form/blob/38a41274940e98a50b30d6991722d780ffe00189/packages/Fable.Form.Simple.Bulma/Form.fs) implementation. It is done in less than 500 lines of code.
+You can take a look at [Fable.Form.Simple.Bulma](https://github.com/MangelMaxime/Fable.Form/blob/main/packages/Fable.Form.Simple.Bulma/Form.fs) implementation. It is done in less than 500 lines of code.


### PR DESCRIPTION
This page confused me - `htmlViewConfig` is annotated with an old version of `CustomConfig` that has only one type parameter, whereas the version on main has two. I've updated the code snippet to be what's currently on main, and the link to refer to main rather than a particular version of the code.

I think this PR still needs some changes: the type argument `IReactProperty` is appropriate for Feliz, but I'm not certain what's appropriate for Fable.React. However, in order to get a fix out sooner, I thought that I'd get the conversation started with this PR rather than wait until I knew all the answers.