### PR TITLE
Add initialize function

### DIFF
--- a/packages/Fable.Form.Simple/Form.fs
+++ b/packages/Fable.Form.Simple/Form.fs
@@ -933,6 +933,14 @@ module Form =
                         |}
             }
 
+        let initialize<'T when 'T : (new : unit -> 'T)> () : 'T =
+            let instance = new 'T()
+            let properties = typeof<'T>.GetProperties()
+            for prop in properties do
+                if prop.PropertyType = typeof<string> then
+                    prop.SetValue(instance, "")
+            instance
+
         let setLoading (formModel: Model<'Values>) =
             { formModel with
                 State = Loading


### PR DESCRIPTION
This is an example of something that's been pestering me - that a type has to be re-created in the init just to instantiate the model. 

```fsharp 
let private init () =
    let initialForm = {
            Name = ""
            Email = ""
            Message = ""
            ClientIP = ""
        }
    { Message = "Feel Free To Reach Out"
      ContactForm = Form.View.idle initialForm }, Cmd.none
```
It seems weird to have to go to all the trouble of defining a type and then to have to *hand-jam* it once again in an init.

The idea I had was to create an "initialize" function [maybe "init" would be better?] to make it a bit more concise. I'm "cheating" right now in this example and only dealing with strings, as I'm sure it will open a Pandora's box of decisions to make (like how to initialize booleans, etc) but I just wanted to plant the idea. 

The result that I was targeting would look something like this. 

```fsharp 
let private init () =
    { Message = "Feel Free To Reach Out"
      ContactForm = Form.View.initialize ContactForm }, Cmd.none
```