### PR TITLE
Fix typo in the documentation

### DIFF
--- a/docs/Fable.Form.Simple.Bulma/usage-with-react.fsx
+++ b/docs/Fable.Form.Simple.Bulma/usage-with-react.fsx
@@ -15,7 +15,7 @@ title: React only
 
 (**
 
-This section will show you how to use `Fable.Form` with Elmish.
+This section will show you how to use `Fable.Form` with React.
 
 <ul class="textual-steps">
 <li>


### PR DESCRIPTION
Replaced the word Elmish with the word React in the documentation for using Fable.Form with React.